### PR TITLE
Add Windows support to `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,2 +1,7 @@
+[unix]
 build:
     ./gradlew -x test patchPluginXml buildPlugin
+
+[windows]
+build:
+    gradlew -x test patchPluginXml buildPlugin


### PR DESCRIPTION
Windows does not play well with `./` - and `just` supports Windows special commands.

(For some more sophisticated use of `just` see https://github.com/JabRef/jabref/blob/main/justfile and https://blog.jabref.org/2025/05/31/run-pr/)